### PR TITLE
feat(animation_widget): add onComplete callback

### DIFF
--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -27,6 +27,9 @@ class SpriteAnimationWidget extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
+  /// A callback that is called when the animation completes.
+  final VoidCallback? _onComplete;
+
   const SpriteAnimationWidget({
     required SpriteAnimation animation,
     required SpriteAnimationTicker animationTicker,
@@ -36,7 +39,8 @@ class SpriteAnimationWidget extends StatelessWidget {
   })  : _animationFuture = animation,
         _animationTicker = animationTicker,
         errorBuilder = null,
-        loadingBuilder = null;
+        loadingBuilder = null,
+        _onComplete = null;
 
   /// Loads image from the asset [path] and renders it as a widget.
   ///
@@ -48,22 +52,27 @@ class SpriteAnimationWidget extends StatelessWidget {
     required String path,
     required SpriteAnimationData data,
     Images? images,
+    VoidCallback? onComplete,
     this.playing = true,
     this.anchor = Anchor.topLeft,
     this.errorBuilder,
     this.loadingBuilder,
     super.key,
   })  : _animationFuture = SpriteAnimation.load(path, data, images: images),
-        _animationTicker = null;
+        _animationTicker = null,
+        _onComplete = onComplete;
 
   @override
   Widget build(BuildContext context) {
     return BaseFutureBuilder<SpriteAnimation>(
       future: _animationFuture,
       builder: (_, spriteAnimation) {
+        final ticker = _animationTicker ?? spriteAnimation.ticker();
+        ticker.completed.then((_) => _onComplete?.call());
+
         return InternalSpriteAnimationWidget(
           animation: spriteAnimation,
-          animationTicker: _animationTicker ?? spriteAnimation.ticker(),
+          animationTicker: ticker,
           anchor: anchor,
           playing: playing,
         );

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -119,5 +119,33 @@ Future<void> main() async {
         }
       },
     );
+
+    testWidgets(
+      'onComplete callback is called when the animation is finished',
+      (tester) async {
+        const imagePath = 'test_path';
+        Flame.images.add(imagePath, image);
+        final spriteAnimationData = SpriteAnimationData.sequenced(
+          amount: 1,
+          stepTime: 0.1,
+          textureSize: Vector2(16, 16),
+          loop: false,
+        );
+
+        var onCompleteCalled = false;
+
+        await tester.pumpWidget(
+          SpriteAnimationWidget.asset(
+            path: imagePath,
+            data: spriteAnimationData,
+            onComplete: () => onCompleteCalled = true,
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(onCompleteCalled, isTrue);
+      },
+    );
   });
 }


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

Adds optional onComplete callback to `SpriteAnimationWidget` for `asset` constructor.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
